### PR TITLE
Arregla bug de export de background del menu inicial

### DIFF
--- a/gameProject/src/Main.tscn
+++ b/gameProject/src/Main.tscn
@@ -1,3 +1,7 @@
-[gd_scene format=2]
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://src/user_interface/StateInitialUI.tscn" type="PackedScene" id=1]
 
 [node name="Main" type="Node2D"]
+
+[node name="StateInitialUI" parent="." instance=ExtResource( 1 )]

--- a/gameProject/src/user_interface/StateInitialUI.tscn
+++ b/gameProject/src/user_interface/StateInitialUI.tscn
@@ -28,8 +28,8 @@ font_data = ExtResource( 11 )
 [node name="StateInitialUI" instance=ExtResource( 1 )]
 
 [node name="Background" type="Sprite" parent="." index="0"]
-position = Vector2( 959.273, 541.156 )
-scale = Vector2( 0.197629, 0.198901 )
+position = Vector2( 962.602, 539.013 )
+scale = Vector2( 1.7446, 1.75832 )
 texture = ExtResource( 4 )
 
 [node name="PlayButton" type="TextureButton" parent="." index="1"]


### PR DESCRIPTION
tamaño muy grande de background.png impedía que se exporte correctamente a Android.